### PR TITLE
Anchor buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "graphql-tag": "^2.7.3",
     "loadable-components": "^1.1.1",
     "react": "^16.2.0",
+    "react-anchor-link-smooth-scroll": "^1.0.5",
     "react-apollo": "^2.0.4",
     "react-dom": "^16.2.0",
     "react-helmet": "^5.2.0",

--- a/src/Components/Adjustable/SingleBase.js
+++ b/src/Components/Adjustable/SingleBase.js
@@ -5,13 +5,14 @@ import { Helmet } from "react-helmet";
 import BreadCrumbs, { BreadWrapper } from '../BreadCrumbs/BreadCrumbs';
 import { Wrapper, Main, MainInfo, PriceWrapper,
   Price, PriceTitle, Warranty, Description, Overview,
-        Article, StyledMarkDown, Profile, MainTitle }
+        Article, StyledMarkDown, Profile, MainTitle, InfoAnchor, Stuff }
         from '../SingleMattress/SingleMattStyles';
 import DropDown from '../DropDrown/index';
 import ImageViewer from '../ImageViewer/ImageViewer';
 import Loading from '../Loading/Loading';
 import { Redirect } from 'react-router-dom';
 import Error from '../Error/Error';
+
 
 const SingleBase = ({data: { loading, error, base}}) => {
   if (error) return <Error/>
@@ -43,7 +44,10 @@ const SingleBase = ({data: { loading, error, base}}) => {
         <Main>
           <ImageViewer cover={base.coverImg.handle} img1={base.detail1.handle} img2={base.detail2.handle} type={'adjustable base without mattress'} fullname={base.fullName}/>
           <MainInfo>
-            <StyledMarkDown source={base.features} escapeHtml={false} />
+            <Stuff>
+              <StyledMarkDown source={base.features} escapeHtml={false} />
+              <InfoAnchor href="#moreInfo">See more details</InfoAnchor>
+            </Stuff>
             <PriceWrapper>
               <Price>
                 <PriceTitle>Base Price</PriceTitle>
@@ -52,7 +56,7 @@ const SingleBase = ({data: { loading, error, base}}) => {
             </PriceWrapper>
           </MainInfo>
         </Main>
-        <Overview>
+        <Overview id="moreInfo">
           <h2>OVERVIEW & SPECS</h2>
         </Overview>
         <Article>

--- a/src/Components/SingleMattress/SingleMattStyles.js
+++ b/src/Components/SingleMattress/SingleMattStyles.js
@@ -1,6 +1,7 @@
+import AnchorLink from 'react-anchor-link-smooth-scroll'
 import styled from 'styled-components';
 import Markdown from 'react-markdown';
-import {Red, FlexCol, FlexRow, MainFont1, MainFont2,
+import {Red, Blue, FlexCol, FlexRow, MainFont1, MainFont2,
   TextShadow, FadeIn, Border, BoxShadow, Animation,
   RedBorderBottom, H2} from '../../Styles';
 
@@ -238,4 +239,22 @@ export const PriceTitle = styled.p`
     margin-bottom: 5px;
     margin-top: 5px;
   }
+`;
+
+export const Stuff = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`
+
+export const InfoAnchor = styled(AnchorLink)`
+  display: none;
+  align-self: center;
+  font-family: ${MainFont2};
+  color: ${Red};
+  &:hover { color: ${Blue}; }
+  @media(min-width: 1024px) { 
+    font-size: 1.3rem;
+    display: block;
+    }
 `;

--- a/src/Components/SingleMattress/SingleMattStyles.js
+++ b/src/Components/SingleMattress/SingleMattStyles.js
@@ -16,6 +16,7 @@ export const Wrapper = FlexCol.extend`
   ${Animation}
   justify-content: center; 
   border-radius: .11rem;
+  
   /* margin-top: 15px; */
   @media(min-width: 1300px) {
     margin-right: 85px;
@@ -30,11 +31,14 @@ export const Main = FlexRow.extend`
   @media(min-width: 1024px) { 
     justify-content: space-evenly;
     margin-left: 5px; 
-    margin-bottom: 20px;}
+    margin-bottom: 10px;}
 `;
 
 export const MainInfo = FlexCol.extend`
   justify-content: space-around;
+  /* @media(min-width: 1024px) {
+    justify-content: space-between;
+  } */
 `;
 
 export const PriceWrapper = FlexCol.extend`
@@ -147,11 +151,11 @@ export const Profile = styled.p`
   font-family: ${MainFont2};
   margin-top: 0;
   font-size: .9rem;
-  @media(min-width: 768px) { font-size: 1.3rem; }
-  @media(min-width: 1024px) { font-size: 1.6rem; }
-  @media(min-width: 1300px) { font-size: 2rem; }
+  @media(min-width: 768px) { font-size: 1rem; }
+  @media(min-width: 1024px) { font-size: 1.2rem; }
+  @media(min-width: 1300px) { font-size: 1.4rem; }
 `;
-
+//692px
 export const StyledMarkDown = styled(Markdown)`
   font-family: ${MainFont2};
   margin-left: 5px;
@@ -173,9 +177,9 @@ export const StyledMarkDown = styled(Markdown)`
   & li {
     padding-bottom: 2px;
   }
-  @media(min-width: 692px) {
+  @media(min-width: 550px) {
     font-family: ${MainFont2};
-    padding: 10px 30px 10px 30px;
+    padding: 0px 0px 0px 10px;
 
     & p {
       font-size: 1.8rem;
@@ -195,7 +199,7 @@ export const StyledMarkDown = styled(Markdown)`
     }
   }
   @media(min-width: 992px) {
-    padding: 30px;
+    padding: 0px 30px 10px 30px;
     
     & p {
       font-size: 2.4rem;
@@ -245,16 +249,70 @@ export const Stuff = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
+  /* @media(min-width: 1024px) {
+    margin-bottom: 25px;
+  } */
 `
 
 export const InfoAnchor = styled(AnchorLink)`
   display: none;
-  align-self: center;
+  /* align-self: center; */
+  margin-left: 5px;
+  padding-left: 15px;
+  font-size: .9rem;
   font-family: ${MainFont2};
   color: ${Red};
   &:hover { color: ${Blue}; }
-  @media(min-width: 1024px) { 
-    font-size: 1.3rem;
+  @media (orientation: landscape) {
     display: block;
+  }
+  @media(min-width: 568px) {
+    padding-left: 30px;
+    font-size: 1rem;
+  }
+  @media(min-width: 768px) {
+    display: block;
+    font-size: 1.2rem;
+  }
+  @media(min-width: 1024px) { 
+    padding-left: 55px;
+    font-size: 1.6rem;
+    
     }
 `;
+
+// export const AnchorLink2 = styled(AnchorLink)`
+//   display: none;
+//   padding: 5px 8px 5px 8px;
+//   margin-left: 40px;
+//   font-size: .8rem;
+//   font-family: ${MainFont2};
+//   color: white;
+//   background-color: ${Red};
+//   text-decoration: none;
+//   align-self: flex-start;
+//   transition: all .25s ease-in;
+//   &:hover { 
+//     background-color: ${Blue};
+//     transform: scale3d(1.1,1.1,1);
+//   }
+//   a:visited {
+//     background-color: ${Red};
+//   }
+//   @media (orientation: landscape) {
+//     display: block;
+//   }
+//   @media(min-width: 731px) {
+//     margin-left: 30px;
+//     font-size: 1rem;
+//     padding: 10px;
+//   }
+//   @media(min-width: 768px) {
+//     display: block;
+//   }
+//   @media(min-width: 1024px) { 
+//     margin-left: 55px;
+//     font-size: 1.6rem;
+//     padding: 15px;
+//     }
+// `;

--- a/src/Components/SingleMattress/SingleMattress.js
+++ b/src/Components/SingleMattress/SingleMattress.js
@@ -6,7 +6,7 @@ import { Wrapper, MainTitle, Main,
         MainInfo, PriceWrapper,
         Price, PriceTitle, Article,
         Overview, Warranty, Description,
-        StyledMarkDown, Profile } from './SingleMattStyles';
+        StyledMarkDown, Profile, InfoAnchor, Stuff } from './SingleMattStyles';
 
 import Loading from '../Loading/Loading';
 import { Redirect } from 'react-router-dom';
@@ -52,7 +52,10 @@ const SingleMattress = ({ data: { loading, error, mattress } }) => {
       <Main>
         <ImageViewer cover={mattress.coverImg.handle} img1={mattress.detail1.handle} img2={mattress.detail2.handle} fullname={mattress.name} type={'mattress'}/>
         <MainInfo>
-          <StyledMarkDown source={mattress.features} escapeHtml={false} />
+          <Stuff>
+            <StyledMarkDown source={mattress.features} escapeHtml={false} />
+            <InfoAnchor href="#moreInfo">See more details</InfoAnchor>
+          </Stuff>
           <PriceWrapper>
             <Price>
               <PriceTitle>Mattress Only Price</PriceTitle>
@@ -65,7 +68,7 @@ const SingleMattress = ({ data: { loading, error, mattress } }) => {
           </PriceWrapper>
         </MainInfo>
       </Main>
-      <Overview>
+      <Overview id="moreInfo">
         <h2>OVERVIEW & SPECS</h2>
       </Overview>
       <Article>

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import { ApolloClient } from 'apollo-client';
 import { HttpLink } from 'apollo-link-http';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { ApolloProvider } from 'react-apollo'; 
-import { persistCache } from 'apollo-cache-persist';
+// import { persistCache } from 'apollo-cache-persist';
 import App from './App';
 
 
@@ -22,10 +22,10 @@ const client = new ApolloClient({
   connectToDevTools: true
 });
 
-persistCache({
-  cache: client.cache,
-  storage: window.localStorage
-})
+// persistCache({
+//   cache: client.cache,
+//   storage: window.localStorage
+// })
 
 
 ReactDOM.render(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5400,6 +5400,10 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-anchor-link-smooth-scroll@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/react-anchor-link-smooth-scroll/-/react-anchor-link-smooth-scroll-1.0.5.tgz#2c6d88660258d8d1203d5cd9723be88be7c77e77"
+
 react-apollo@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.0.4.tgz#01dd32a8e388672f5d7385b21cdd0b94009ee9ee"


### PR DESCRIPTION
Finished anchor tag. The goal was to make a 'get more details' button in singleMattress and singleBase components to 'smoothly scroll' to the details div in same component. I used an NPM package called [react-anchor-link-smooth-scroll](https://github.com/mauricevancooten/react-anchor-link-smooth-scroll) to quickly accomplish this. It uses a smooth scrolling poly-fill and not native smooth scrolling. In the future I would like to read up on the native option and implement it myself. The anchor its self only displays in landscape or 1024 width.
 !TODO! fix background color change on visited tag !TODO!
Also added an extra styled-component called 'AnchorLink2' that has more of a button look to it. Check with Will to see which one he likes tomorrow. 
----MVP done --- marge and deploy