### PR TITLE
breadcrumbs in error and 404 components

### DIFF
--- a/src/Components/Adjustable/Adjustable.js
+++ b/src/Components/Adjustable/Adjustable.js
@@ -9,7 +9,7 @@ import Error from '../Error/Error';
 import BreadCrumbs, { BreadWrapper } from '../BreadCrumbs/BreadCrumbs';
 
 const AdjustableComponent = ({ data: {error, loading, Bases} }, client) => {
-  if (error) return <Error/>
+  if (error) return <Error next="adjustable" error={true} only2Links={true}/>
   if (!loading) {
     return (
     <Main MarginTop>

--- a/src/Components/Adjustable/SingleBase.js
+++ b/src/Components/Adjustable/SingleBase.js
@@ -14,8 +14,8 @@ import { Redirect } from 'react-router-dom';
 import Error from '../Error/Error';
 
 
-const SingleBase = ({data: { loading, error, base}}) => {
-  if (error) return <Error/>
+const SingleBase = ({data: { loading, error, base}, match}) => {
+  if (error) return <Error next="adjustable" next2={match.params.uri} error={true} only3Links={true}/>
   if (!loading) {
     if(!base) return <Redirect to='/404'/>
     return(

--- a/src/Components/Blog/Blog.js
+++ b/src/Components/Blog/Blog.js
@@ -11,7 +11,7 @@ import Error from '../Error/Error';
 const POSTS_PER_PAGE = 4
 
 const BlogComponent = ({ data: { loading, error, allPosts, _allPostsMeta}, loadMorePosts}) => {
-  if (error) return <Error/>
+  if (error) return <Error next="blog" error={true} only2Links={true}/>
   if (allPosts && _allPostsMeta) {
     const areMorePosts = allPosts.length < _allPostsMeta.count
 

--- a/src/Components/Blog/Post/Post.js
+++ b/src/Components/Blog/Post/Post.js
@@ -9,8 +9,8 @@ import Error from '../../Error/Error';
 import { H2 } from '../../../Styles'
 import BreadCrumbs, { BreadWrapper } from '../../BreadCrumbs/BreadCrumbs';
 
-const Post = ({ data: { loading, error, post } }) => {
-  if (error) return <Error/>
+const Post = ({ data: { loading, error, post }, match }) => {
+  if (error) return <Error next="blog" next2={match.params.slug} only3Links={true}/>
   if (!loading) {
     if(!post) return <Redirect to='/404'/>
     return (

--- a/src/Components/BreadCrumbs/BreadCrumbs.js
+++ b/src/Components/BreadCrumbs/BreadCrumbs.js
@@ -63,16 +63,16 @@ const BreadCrumbs = (props) => {
       <div>
         
         <Crumbs to={`/${props.next}`}>{props.next}</Crumbs>
-        <Span>></Span>
+        {!props.only2Links ? <Span>></Span> : ''}
       </div>
       }
       {props.next2&&
         <div>
         <Crumbs to={`/${props.next}/${props.next2}`}>{props.next2}</Crumbs>
-        <Span>></Span>
+        {!props.only3Links ? <Span>></Span> : ''}
         </div>
       }
-      <Location>{props.here}</Location>
+      <Location>{props.error ? <Crumbs to={`/${props.next}/${props.next2}/${props.here}`}>{props.here}</Crumbs>: props.here}</Location>
     </Fragment>
   )
 }

--- a/src/Components/Error/Error.js
+++ b/src/Components/Error/Error.js
@@ -2,13 +2,23 @@ import React from 'react'
 import { Main, Img } from '../Panda404/Panda404Styles';
 import { H2 } from '../../Styles';
 import { Link } from 'react-router-dom';
+import BreadCrumbs, { BreadWrapper } from '../BreadCrumbs/BreadCrumbs';
+
 import image from '../../images/ezgif.com-optimize.gif';
-const Error = () => {
+const Error = (props) => {
   return (
-    <Main>
-      <H2>Our panda's are having trouble finding the page you requested</H2>
-      <Link to='/' title="Home"><Img src={image} alt="E S C Mattress Center Sleeping Panda "/></Link>
-    </Main>
+    <div>
+      <BreadWrapper>
+        <BreadCrumbs next={props.next} next2={props.next2} here={props.here} error={props.error} only2Links={props.only2Links} only3Links={props.only3Links}/>
+      </BreadWrapper>
+      <Main>
+        <H2>Our panda's are having trouble finding the page you requested</H2>
+        <Link to='/' title="Home"><Img src={image} alt="E S C Mattress Center Sleeping Panda "/></Link>
+      </Main>
+      <BreadWrapper>
+        <BreadCrumbs next={props.next} next2={props.next2} here={props.here} error={props.error} only2Links={props.only2Links} only3Links={props.only3Links}/>
+      </BreadWrapper>
+    </div>
   )
 }
 

--- a/src/Components/MattressList/Sealy.js
+++ b/src/Components/MattressList/Sealy.js
@@ -12,7 +12,7 @@ import BreadCrumbs, { BreadWrapper } from '../BreadCrumbs/BreadCrumbs';
 
 const Sealy = ({ data: { loading, error, essentials, performance, premium} }) => {
   const title = 'sealy';
-  if (error) return <Error/>
+  if (error) return <Error next="brands" next2="sealy" only3Links={true}/>
   if(!loading) {
     return (
       <MainWrapper>

--- a/src/Components/MattressList/Stearns.js
+++ b/src/Components/MattressList/Stearns.js
@@ -13,7 +13,7 @@ import BreadCrumbs, { BreadWrapper } from '../BreadCrumbs/BreadCrumbs';
 
 const Stearns = ({ data: { loading, error, Brands} }) => {
   const title = 'stearns';
-  if (error) return <Error/>
+  if (error) return <Error next="brands" next2="stearns" only3Links={true}/>
   if(!loading) {
     return (
       <MainWrapper>

--- a/src/Components/MattressList/Tempur.js
+++ b/src/Components/MattressList/Tempur.js
@@ -15,7 +15,7 @@ import BreadCrumbs, { BreadWrapper } from '../BreadCrumbs/BreadCrumbs';
 const Tempur = ({ data: { loading, error, Brands} }) => {
   const title = 'tempurpedic';
 
-  if (error) return <Error/>
+  if (error) return <Error next="brands" next2="tempurpedic" only3Links={true}/>
   if(!loading) {
     return (
       <MainWrapper>

--- a/src/Components/Panda404/Panda404.js
+++ b/src/Components/Panda404/Panda404.js
@@ -3,15 +3,24 @@ import image from '../../images/ezgif.com-optimize.gif';
 import { Main, Img } from './Panda404Styles';
 import { Link } from 'react-router-dom';
 import { H2 } from '../../Styles';
+import BreadCrumbs, { BreadWrapper } from '../BreadCrumbs/BreadCrumbs';
 
-const Panda404 = () => {
+const Panda404 = (props) => {
   return (
-    <Main>
-      <header>
-        <H2>Our panda couldn't find the product you're looking for...</H2>
-      </header>
-      <Link to='/'><Img src={image} alt="E S C Mattress Center Sleeping Panda "/></Link>
-    </Main>
+    <div>
+      <BreadWrapper>{console.log(props)}
+        <BreadCrumbs next={props.next} next2={props.next2} here={props.here} error={props.error} only2Links={props.only2Links} only3Links={props.only3Links}/>
+      </BreadWrapper> 
+      <Main>
+        <header>
+          <H2>Our panda couldn't find the product you're looking for...</H2>
+        </header>
+        <Link to='/'><Img src={image} alt="E S C Mattress Center Sleeping Panda "/></Link>
+      </Main>
+      <BreadWrapper>
+        <BreadCrumbs next={props.next} next2={props.next2} here={props.here} error={props.error} only2Links={props.only2Links} only3Links={props.only3Links}/>
+      </BreadWrapper>
+    </div>
   )
 };
 

--- a/src/Components/SingleMattress/SingleMattress.js
+++ b/src/Components/SingleMattress/SingleMattress.js
@@ -13,10 +13,7 @@ import ImageViewer from '../ImageViewer/ImageViewer';
 import Error from '../Error/Error';
 import BreadCrumbs, { BreadWrapper } from '../BreadCrumbs/BreadCrumbs';
 
-const SingleMattress = ({ data: { loading, error, mattress } }) => {
-  if (error) return <Error/>
-  if (!loading) {
-  if(!mattress) return <Redirect to='/404'/>
+const SingleMattress = ({ data: { loading, error, mattress }, match }) => {
   const SealyBoxPrice = [100, 100, 100, 100, 200];
   const StearnsBoxPrice = [125, 125, 150, 150, 250];
   const TempurBoxPrice = [175, 175, 250, 250, 350]; 
@@ -32,6 +29,10 @@ const SingleMattress = ({ data: { loading, error, mattress } }) => {
       BoxspringPrice = StearnsBoxPrice;
       name = 'stearns'
     }
+  if (error) return <Error next="Brands" next2={name.charAt(0).toUpperCase() + name.slice(1)} here={match.params.uri} error={true}/>
+  if (!loading) {
+  if(mattress) return <Redirect to='/404'/>
+ 
   return (
     <div>
       <Helmet>

--- a/src/Components/SiteMap/SiteMap.js
+++ b/src/Components/SiteMap/SiteMap.js
@@ -10,7 +10,7 @@ import Error from '../Error/Error';
 
 
 const SiteMap = ({ data: { loading, error, Sealy, Stearns, Tempur, Ajustable, Blog} }) => {
-  if (error) return <Error/>
+  if (error) return <Error next={'sitemap'} only2Links={true}/>
   if(!loading) {
     return (
       <Fragment>


### PR DESCRIPTION
-added breadcrumbs to error and 404
-passed props needed through error and 404
-added boolean flag 'only2Links' and 'only3Links to not render the '>' symble after the last link
-added 'error' boolean True to make last link clickable false to make it just text